### PR TITLE
Update index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -685,9 +685,9 @@ services:
 </code></pre>
 
 <h2 id="how-to-use-api-v2">How to use API (v2)</h2>
-<p>Check it out <a href="./app/docs/api_docs/v2.md">here</a></p>
+<p>Check it out <a href="https://nuttaphat.com/covid19-api/docs/api_docs/v2/">here</a></p>
 <h2 id="how-to-use-api-v1">How to use API (v1)</h2>
-<p>Check it out <a href="./app/docs/api_docs/v1.md">here</a></p>
+<p>Check it out <a href="https://nuttaphat.com/covid19-api/docs/api_docs/v1/">here</a></p>
 <h2 id="contributors">Contributors ✨</h2>
 <p>Thanks goes to these wonderful people (<a href="https://allcontributors.org/docs/en/emoji-key">emoji key</a>):</p>
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->


### PR DESCRIPTION
### Related Issue:

The gh-pages links for API v1 and v2 on the documentation pointed to a .md file path instead of the correct file path of 

https://nuttaphat.com/covid19-api/docs/api_docs/v1/
https://nuttaphat.com/covid19-api/docs/api_docs/v2/
Respectively

### Proposed Changes

Updated the links for the gh-pages documentation

