### PR TITLE
Aggregation

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,11 +1,13 @@
 ### Related Issue:
 
-* Issue goes here
+* Aggregation could be applied to the code design in certain spots
+* I've added some aggregation in the covid_api_v2_models.py class
+
+
 
 ### Proposed Changes
 
-* change 1
-* change 2
+* The CurrentModel class can be inherited by several other classes like ConfirmedModel, DeathsModel, RecoveredModel, ActiveModel, CountryModel and TotalModel to make the design smoother
 
 ### Addtional Info
 
@@ -20,3 +22,4 @@
 ### Screenshots
 
 * screenshot 1
+![CurrentAggregation](https://user-images.githubusercontent.com/56807471/111401179-2692a980-869f-11eb-8d2f-9344e0025d2b.png)

--- a/app/models/covid_api_v2_model.py
+++ b/app/models/covid_api_v2_model.py
@@ -13,7 +13,7 @@ from pydantic import BaseModel
 #######################################
 # CurrentModel
 #######################################
-class CurrentModel(BaseModel):
+class CurrentModel(BaseModel, ConfirmedModel, DeathsModel, RecoveredModel, ActiveModel, CountryModel): #changes made right here
     location: str
     confirmed: int
     deaths: int

--- a/app/models/covid_api_v2_model.py
+++ b/app/models/covid_api_v2_model.py
@@ -13,11 +13,14 @@ from pydantic import BaseModel
 # CurrentModel
 #######################################
 class CurrentModel(BaseModel): #changes made right here
-    location: str
-    confirmed: int
-    deaths: int
-    recovered: int
-    active: int
+    def __init__(self):
+        self.location: str
+        self.confirmed: int
+        self.deaths: int
+        self.recovered: int
+        self.active: int
+   
+    
 
 
 #######################################
@@ -34,39 +37,48 @@ class CurrentUSModel(BaseModel):
 # ConfirmedModel
 #######################################
 class ConfirmedModel(CurrentModel): ### Changes made right here - ConfirmedModel now inherits confirmed value from CurrentModel
-    confirmed: int
+    def __init__(self):
+        CurrentModel.__init__(confirmed)
+        confirmed: int
 
 
 #######################################
 # DeathsModel
 #######################################
 class DeathsModel(CurrentModel):   ### Changes made right here - DeathsModel now inherits deaths value from CurrentModel
-    deaths: int
+     def __init__(self):
+        CurrentModel.__init__(deaths)
+        deaths: int
 
 
 #######################################
 # RecoveredModel
 #######################################
 class RecoveredModel(CurrentModel):    ### Changes made right here - RecoveredModel now inherits recovered values from CurrentModel
-    recovered: int
+        def __init__(self):
+        CurrentModel.__init__(recovered)
+        recovered: int
 
 
 #######################################
 # ActiveModel
 #######################################
-class ActiveModel(CurrentModel):      ### Changes made right here - ActiveModel now inherits recovered values from CurrentModel
-    active: int
+class ActiveModel(CurrentModel):      ### Changes made right here - ActiveModel now inherits recovered values from CurrentModel    def __init__(self):
+    CurrentModel.__init__(active)
+        active: int
 
 
 #######################################
 # CountryModel
 #######################################
 class CountryModel(CurrentModel):      ### Changes made right here - ActiveModel now inherits recovered values from CurrentModel
-    location: str
-    confirmed: int
-    deaths: int
-    recovered: int
-    active: int
+   def __init__(self):
+   CurrentModel.__init__(confirmed, location, deaths, recovered, active)
+        location: str
+        confirmed: int
+        deaths: int
+        recovered: int
+        active: int
 
 
 
@@ -76,10 +88,13 @@ class CountryModel(CurrentModel):      ### Changes made right here - ActiveModel
 # TotalModel
 #######################################
 class TotalModel(CurrentModel):       ### Changes made here - TotalModel can inherit values from GetCurrent and use them as part of the aggregation
-    confirmed: int
-    deaths: int
-    recovered: int
-    active: int
+    def __init__(self):
+    CurrentModel.__init__(confirmed)
+        confirmed: int
+        deaths: int
+        recovered: int
+        active: int
+
 
 
 

--- a/app/models/covid_api_v2_model.py
+++ b/app/models/covid_api_v2_model.py
@@ -9,11 +9,10 @@ from typing import List
 
 from pydantic import BaseModel
 
-
 #######################################
 # CurrentModel
 #######################################
-class CurrentModel(BaseModel, ConfirmedModel, DeathsModel, RecoveredModel, ActiveModel, CountryModel): #changes made right here
+class CurrentModel(BaseModel): #changes made right here
     location: str
     confirmed: int
     deaths: int
@@ -31,54 +30,58 @@ class CurrentUSModel(BaseModel):
     Recovered: int
     Active: int
 
-
-#######################################
-# TotalModel
-#######################################
-class TotalModel(BaseModel):
-    confirmed: int
-    deaths: int
-    recovered: int
-    active: int
-
-
 #######################################
 # ConfirmedModel
 #######################################
-class ConfirmedModel(BaseModel):
+class ConfirmedModel(CurrentModel): ### Changes made right here - ConfirmedModel now inherits confirmed value from CurrentModel
     confirmed: int
 
 
 #######################################
 # DeathsModel
 #######################################
-class DeathsModel(BaseModel):
+class DeathsModel(CurrentModel):   ### Changes made right here - DeathsModel now inherits deaths value from CurrentModel
     deaths: int
 
 
 #######################################
 # RecoveredModel
 #######################################
-class RecoveredModel(BaseModel):
+class RecoveredModel(CurrentModel):    ### Changes made right here - RecoveredModel now inherits recovered values from CurrentModel
     recovered: int
 
 
 #######################################
 # ActiveModel
 #######################################
-class ActiveModel(BaseModel):
+class ActiveModel(CurrentModel):      ### Changes made right here - ActiveModel now inherits recovered values from CurrentModel
     active: int
 
 
 #######################################
 # CountryModel
 #######################################
-class CountryModel(BaseModel):
+class CountryModel(CurrentModel):      ### Changes made right here - ActiveModel now inherits recovered values from CurrentModel
     location: str
     confirmed: int
     deaths: int
     recovered: int
     active: int
+
+
+
+
+
+#######################################
+# TotalModel
+#######################################
+class TotalModel(CurrentModel):       ### Changes made here - TotalModel can inherit values from GetCurrent and use them as part of the aggregation
+    confirmed: int
+    deaths: int
+    recovered: int
+    active: int
+
+
 
 
 #######################################


### PR DESCRIPTION
### Related Issue:

* Aggregate patterns could be applied to covid_api_v2_model.py class since each of the getters inherit BaseModel and CurrentModel already holds many values that could be reused by the getters
* 
### Proposed Changes

* Getters whose values can be fully covered from CurrentModel class now inherit CurrentModel class and reuse those values instead of calling the BaseModel class again

### Addtional Info

- any additional information or context

### Checklist

* [ ] Tests
* [ ] Translations
* [ ] Documentation

### Screenshots

* screenshot 1
