### PR TITLE
Aggregate Pattern #1: Wrapper Class for V1 & V2

### DIFF
--- a/app/integrators/covid_api_v2_integrator.py
+++ b/app/integrators/covid_api_v2_integrator.py
@@ -24,9 +24,7 @@ from models.covid_api_v2_model import (ActiveModel, ConfirmedModel,
                                          TimeseriesUSDataModel,
                                          TimeseriesUSInfoModel,
                                          TimeseriesUSModel, TotalModel)
-from utils.get_data import (get_data_daily_reports,
-                              get_data_daily_reports_us, get_data_lookup_table,
-                              get_data_time_series, get_US_time_series)
+from utils.get_data import get_data_v2
 
 
 class CovidAPIv2Integrator:
@@ -39,7 +37,7 @@ class CovidAPIv2Integrator:
     """
     def __init__(self) -> None:
         """ Initiate DataFrames """
-        self.lookup_table = get_data_lookup_table()
+        self.lookup_table = get_data_v2.get_data_lookup_table()
         self.scheme = {
             'data': None,
             'dt': None,
@@ -71,7 +69,7 @@ class CovidAPIv2Integrator:
     def get_current(self) -> List[CurrentModel]:
         """ Current data from all locations (Lastest date) """
         concerned_columns = ['Confirmed', 'Deaths', 'Recovered', 'Active']
-        self.df = get_data_daily_reports() # Get base data
+        self.df = get_data_v2.get_data_daily_reports() # Get base data
         self.df_grp_by_country = self.df.groupby('Country_Region')[concerned_columns].sum()
         self.df_grp_by_country[concerned_columns] = self.df_grp_by_country[concerned_columns].astype(int)
 
@@ -89,7 +87,7 @@ class CovidAPIv2Integrator:
     @wrap_data
     def get_current_US(self) -> List[CurrentUSModel]:
         """ Get current data for USA's situation """
-        self.df_US = get_data_daily_reports_us() # Get base data
+        self.df_US = get_data_v2.get_data_daily_reports_us() # Get base data
 
         concerned_columns = ['Confirmed', 'Deaths', 'Recovered', 'Active']
         df = self.df_US.groupby(['Province_State'])[concerned_columns].sum().sort_values(by='Confirmed', ascending=False)
@@ -128,7 +126,7 @@ class CovidAPIv2Integrator:
     @wrap_data
     def get_confirmed(self) -> ConfirmedModel:
         """ Summation of all confirmed cases """
-        self.df = get_data_daily_reports() # Get base data
+        self.df = get_data_v2.get_data_daily_reports() # Get base data
         data = ConfirmedModel(
             confirmed=int(self.df['Confirmed'].sum())
         )
@@ -140,7 +138,7 @@ class CovidAPIv2Integrator:
     @wrap_data
     def get_deaths(self) -> DeathsModel:
         """ Summation of all deaths """
-        self.df = get_data_daily_reports() # Get base data
+        self.df = get_data_v2.get_data_daily_reports() # Get base data
         data = DeathsModel(
             deaths=int(self.df['Deaths'].sum())
         )
@@ -152,7 +150,7 @@ class CovidAPIv2Integrator:
     @wrap_data
     def get_recovered(self) -> RecoveredModel:
         """ Summation of all recovers """
-        self.df = get_data_daily_reports() # Get base data
+        self.df = get_data_v2.get_data_daily_reports() # Get base data
         data = RecoveredModel(
             recovered=int(self.df['Recovered'].sum())
         )
@@ -164,7 +162,7 @@ class CovidAPIv2Integrator:
     @wrap_data
     def get_active(self) -> ActiveModel:
         """ Summation of all actives """
-        self.df = get_data_daily_reports() # Get base data
+        self.df = get_data_v2.get_data_daily_reports() # Get base data
         data = ActiveModel(
             active=int(self.df['Active'].sum())
         )
@@ -176,7 +174,7 @@ class CovidAPIv2Integrator:
     @wrap_data
     def get_total(self) -> TotalModel:
         """ Summation of Confirmed, Deaths, Recovered, Active """
-        self.df = get_data_daily_reports() # Get base data
+        self.df = get_data_v2.get_data_daily_reports() # Get base data
         data = TotalModel(
             confirmed=int(self.df['Confirmed'].sum()),
             deaths=int(self.df['Deaths'].sum()),
@@ -194,7 +192,7 @@ class CovidAPIv2Integrator:
             1.) global
             2.) confirmed, deaths, recovered
         """
-        self.df_time_series = get_data_time_series() # Get base data
+        self.df_time_series = get_data_v2.get_data_time_series() # Get base data
 
         if case not in ['global']:
             raw_data = self.df_time_series[case].T.to_dict()
@@ -262,7 +260,7 @@ class CovidAPIv2Integrator:
         if case not in ['confirmed', 'deaths']:
             data = []
         else:
-            self.df_US_time_series = get_US_time_series() # Get base data
+            self.df_US_time_series = get_data_v2.get_US_time_series() # Get base data
             raw_data = self.df_US_time_series[case].T.to_dict()
             data = self.__extract_US_time_series(raw_data)
 

--- a/app/utils/get_data.py
+++ b/app/utils/get_data.py
@@ -16,7 +16,8 @@ from .helper import (helper_df_cleaning, helper_df_cols_cleaning,
 
 
 # Get Lookup table
-def get_data_lookup_table() -> Dict[str, str]:
+class get_data_v2:
+    def get_data_lookup_table() -> Dict[str, str]:
     """ Get lookup table (country references for iso2) """
     lookup_table_url = JHU_CSSE_FILE_PATHS['BASE_URL_LOOKUP_TABLE']
     lookup_df = pd.read_csv(lookup_table_url)[['iso2', 'Country_Region']]
@@ -27,77 +28,74 @@ def get_data_lookup_table() -> Dict[str, str]:
 
     return data
 
+    # Get data from daily reports
+    def get_data_daily_reports() -> pd.DataFrame:
+        """ Get data from BASE_URL_DAILY_REPORTS """
+        # Check the latest file
+        latest_base_url = helper_get_latest_data_url(JHU_CSSE_FILE_PATHS['BASE_URL_DAILY_REPORTS'])
 
-# Get data from daily reports
-def get_data_daily_reports() -> pd.DataFrame:
-    """ Get data from BASE_URL_DAILY_REPORTS """
-    # Check the latest file
-    latest_base_url = helper_get_latest_data_url(JHU_CSSE_FILE_PATHS['BASE_URL_DAILY_REPORTS'])
+        # Extract the data
+        df = pd.read_csv(latest_base_url)
 
-    # Extract the data
-    df = pd.read_csv(latest_base_url)
-
-    # Data pre-processing
-    concerned_columns = ['Confirmed', 'Deaths', 'Recovered', 'Active']
-    df = helper_df_cols_cleaning(df, concerned_columns, int)
-    
-    return df
-
-
-# Get data from daily reports (USA)
-def get_data_daily_reports_us() -> pd.DataFrame:
-    """ Get data from BASE_URL_DAILY_REPORTS """
-    # Check the latest file
-    latest_base_url = helper_get_latest_data_url(JHU_CSSE_FILE_PATHS['BASE_URL_DAILY_REPORTS_US'])
-
-    # Extract the data
-    df = pd.read_csv(latest_base_url)
-
-    # Data pre-processing
-    concerned_columns = ['Confirmed', 'Deaths', 'Recovered', 'Active']
-    df = helper_df_cols_cleaning(df, concerned_columns, int)
-    
-    return df
-
-
-# Get data from time series
-def get_data_time_series() -> Dict[str, pd.DataFrame]:
-    """ Get the dataset from JHU CSSE """
-    dataframes = {}
-
-    # Iterate through all files
-    for category in JHU_CSSE_FILE_PATHS['CATEGORIES']:
-        url = JHU_CSSE_FILE_PATHS['BASE_URL_TIME_SERIES'].format(category)
-
-        # Extract data
-        df = pd.read_csv(url)
-        df = helper_df_cleaning(df)
-        dataframes[category] = df
-
-    return dataframes
-
-
-# Get data from time series (US)
-def get_US_time_series() -> Dict[str, pd.DataFrame]:
-    """ Get the dataset of time series for USA """
-    dataframes = {}
-
-    # Iterate through categories ('confirmed', 'deaths')
-    for category in JHU_CSSE_FILE_PATHS['CATEGORIES'][:-1]:
-        url = JHU_CSSE_FILE_PATHS['BASE_URL_US_TIME_SERIES'].format(category)
+        # Data pre-processing
+        concerned_columns = ['Confirmed', 'Deaths', 'Recovered', 'Active']
+        df = helper_df_cols_cleaning(df, concerned_columns, int)
         
-        # Extract data
-        df = pd.read_csv(url)
-        df = helper_df_cleaning(df)
-        concerned_columns = ['Lat', 'Long_']
-        df = helper_df_cols_cleaning(df, concerned_columns, float)
-        dataframes[category] = df
+        return df
 
-    return dataframes
+    # Get data from daily reports (USA)
+    def get_data_daily_reports_us() -> pd.DataFrame:
+        """ Get data from BASE_URL_DAILY_REPORTS """
+        # Check the latest file
+        latest_base_url = helper_get_latest_data_url(JHU_CSSE_FILE_PATHS['BASE_URL_DAILY_REPORTS_US'])
+
+        # Extract the data
+        df = pd.read_csv(latest_base_url)
+
+        # Data pre-processing
+        concerned_columns = ['Confirmed', 'Deaths', 'Recovered', 'Active']
+        df = helper_df_cols_cleaning(df, concerned_columns, int)
+        
+        return df
+
+    # Get data from time series
+    def get_data_time_series() -> Dict[str, pd.DataFrame]:
+        """ Get the dataset from JHU CSSE """
+        dataframes = {}
+
+        # Iterate through all files
+        for category in JHU_CSSE_FILE_PATHS['CATEGORIES']:
+            url = JHU_CSSE_FILE_PATHS['BASE_URL_TIME_SERIES'].format(category)
+
+            # Extract data
+            df = pd.read_csv(url)
+            df = helper_df_cleaning(df)
+            dataframes[category] = df
+
+        return dataframes
+
+    # Get data from time series (US)
+    def get_US_time_series() -> Dict[str, pd.DataFrame]:
+        """ Get the dataset of time series for USA """
+        dataframes = {}
+
+        # Iterate through categories ('confirmed', 'deaths')
+        for category in JHU_CSSE_FILE_PATHS['CATEGORIES'][:-1]:
+            url = JHU_CSSE_FILE_PATHS['BASE_URL_US_TIME_SERIES'].format(category)
+            
+            # Extract data
+            df = pd.read_csv(url)
+            df = helper_df_cleaning(df)
+            concerned_columns = ['Lat', 'Long_']
+            df = helper_df_cols_cleaning(df, concerned_columns, float)
+            dataframes[category] = df
+
+        return dataframes
 
 
 # API v1
-def get_data(time_series: bool = False) -> Dict[str, pd.DataFrame]:
+class get_data_v1:
+    def get_data(time_series: bool = False) -> Dict[str, pd.DataFrame]:
     """ Get the dataset from JHU CSSE """
     dataframes = {}
 


### PR DESCRIPTION
### Related Issue:

* might have to change all the files that imports get_data()

### Proposed Changes

* Creating a 2 wrapper class _get_data_v1_ and _get_data_v2_ in _get_data.py_ file, to wrap all the methods for API version 1 and 2 into two different classes. The forms an aggregate pattern as the files like  _covid_api_v2_integrator.py_ and _covid_api_v1_integrator.py_ that import methods of get_data.py will now import classes of that file and will have to call the class in order to use a particular method. hence class forms a has-a relationship with its method also separating version 1 and 2 into different groups for better understanding.

### Checklist

* [ ] Tests
* [ ] Translations
* [ ] Documentation

