### PR TITLE
Single Instance

### DIFF
--- a/app/routers/v2/router_api_v2.py
+++ b/app/routers/v2/router_api_v2.py
@@ -17,7 +17,7 @@ from . import v2
 from utils.get_data import DailyReports, DataTimeSeries
 
 # Initiate Integrator
-DAILY_REPORTS = DailyReports()
+DAILY_REPORTS = DailyReports.getInstance()
 DATA_TIME_SERIES = DataTimeSeries()
 COVID_API_V2 = CovidAPIv2Integrator(DAILY_REPORTS, DATA_TIME_SERIES)
 

--- a/app/tests/test_get_data.py
+++ b/app/tests/test_get_data.py
@@ -10,7 +10,7 @@ import pandas as pd
 from ..utils.get_data import (DailyReports, DataTimeSeries, get_data,
                               get_data_lookup_table)
 
-daily_reports = DailyReports()
+daily_reports = DailyReports.getInstance()
 time_series = DataTimeSeries()
 
 

--- a/app/utils/get_data.py
+++ b/app/utils/get_data.py
@@ -30,9 +30,29 @@ def get_data_lookup_table() -> Dict[str, str]:
 
 # Get Daily Reports Data (General and US)
 class DailyReports:
+
+    __instance = None
+
+    @staticmethod
+    def getInstance():
+        if DailyReports.__instance is None:
+            """
+            Static method create a single instance
+            """
+            __instance = DailyReports()
+            return __instance
+
+
     def __init__(self) -> None: 
-        self.latest_base_url = helper_get_latest_data_url(JHU_CSSE_FILE_PATHS['BASE_URL_DAILY_REPORTS'])
-        self.latest_base_US_url = helper_get_latest_data_url(JHU_CSSE_FILE_PATHS['BASE_URL_DAILY_REPORTS_US'])
+        """
+        Dont call the constructor use the static method getInstance
+        """
+        if DailyReports.__instance != None:
+            raise Exception("This is a sinleton class.")
+        else:    
+            self.latest_base_url = helper_get_latest_data_url(JHU_CSSE_FILE_PATHS['BASE_URL_DAILY_REPORTS'])
+            self.latest_base_US_url = helper_get_latest_data_url(JHU_CSSE_FILE_PATHS['BASE_URL_DAILY_REPORTS_US'])
+            DailyReports.__instance = self
 
     # Get data from daily reports
     def get_data_daily_reports(self, US: bool = False) -> pd.DataFrame:


### PR DESCRIPTION
### Related Issue:
Multiple Instances of DailyReports are being created when we can only create a single Instance for the shared resource the databse.

### Proposed Changes
Created a singleton pattern for the DailyReport class in the get_data.py file. Implemented a lazy initialization to reduce the object creation overhead, optimizing the overall data retrieval. We create a single instance in the version 2 router that allows us to pass the single instance to the integrator class which then provides data to the routers. I was unable to create a private constructor due to pythons restrictions, therefore, I have created a constructor that will throw an exception if Instantiated.
In java we can do something like this,
private static instance = null; 
private DailyReport() { 
} 
public static getInstance(){
if(instance == null){
//apply logic to retrieve data
}
return instance;
}

* [passed all 6 test cases for test_get_data.py] Tests

