### PR TITLE
Added another run command in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,12 +105,15 @@ services:
 docker pull nat236919/covid19-api:latest
 ```
 
-* Create a container and run
+* Create a container and run either of the following
 
 ```console
 docker run nat236919/covid19-api
 ```
 
+```console
+docker run -p 80:80 nat236919/covid19-api
+```
 ## How to use API (v2)
 
 Check it out [here](./app/docs/api_docs/v2.md)

--- a/README.md
+++ b/README.md
@@ -110,7 +110,6 @@ docker pull nat236919/covid19-api:latest
 ```console
 docker run nat236919/covid19-api
 ```
-
 ```console
 docker run -p 80:80 nat236919/covid19-api
 ```


### PR DESCRIPTION
### Related Issue:

Trying to load the API on the browser page may fail to load. Specifying the port fixes this issue.

### Proposed Changes

Added another way to create the container and run.

`docker run -p 80:80 nat236919/covid19-api`

### Additional Info


### Checklist

* [ ] Tests
* [ ] Translations
* [ ] Documentation

### Screenshots

