### PR TITLE
Adapter class for CovidAPIv1

### DIFF
--- a/app/adapters/covid_api_v1_integrator_adapter.py
+++ b/app/adapters/covid_api_v1_integrator_adapter.py
@@ -6,11 +6,20 @@ DATE: 11-April-2021
 """
 
 from integrators.covid_api_v1_integrator import CovidAPIv1
+from utils.helper import helper_lookup_country
 
+class ItemNotFoundException(Exception):
+    pass
 
 class CovidAPIv1Adapter:
-    def get_current_status_by_country(country_name: str):
-        raw_data = COVID_API_V1.get_current_status() # Get all current data
+    def __init__(self, covid_v1_api_integrator: CovidAPIv1):
+        self.covid_v1_api = covid_v1_api_integrator
+
+    def get_currrent_status_list(self):
+        return self.covid_v1_api.get_current_status(list_required=True)
+
+    def get_current_status_by_country(self, country_name: str):
+        raw_data = self.covid_v1_api.get_current_status() # Get all current data
         if country_name.lower() not in ['us', 'uk'] and len(country_name) in [2]:
             country_name = helper_lookup_country(country_name)
             data = {k: v for k, v in raw_data.items() if country_name.lower() in k.lower()}
@@ -23,9 +32,8 @@ class CovidAPIv1Adapter:
 
         return data
         
-
-    def get_formatted_timeseries():
-        raw_data = COVID_API_V1.get_time_series()
+    def get_formatted_timeseries(self, case: str):
+        raw_data = self.covid_v1_api.get_time_series()
         case = case.lower()
 
         if case in ['confirmed', 'deaths', 'recovered']:
@@ -33,9 +41,6 @@ class CovidAPIv1Adapter:
             data['dt'] = raw_data['dt']
             data['ts'] = raw_data['ts']
         else:
-            raise HTTPException(status_code=404, detail="Item not found")
+            raise ItemNotFoundException()
 
         return data
-
-    def get_currrent_status_list():
-        return COVID_API_V1.get_current_status(list_required=True)

--- a/app/adapters/covid_api_v1_integrator_adapter.py
+++ b/app/adapters/covid_api_v1_integrator_adapter.py
@@ -1,0 +1,41 @@
+"""
+FILE: covid_api_v1_integrator_adapter.py
+DESCRIPTION: Adapter for Integrators for API v1
+AUTHOR: Jerry CHen
+DATE: 11-April-2021
+"""
+
+from integrators.covid_api_v1_integrator import CovidAPIv1
+
+
+class CovidAPIv1Adapter:
+    def get_current_status_by_country(country_name: str):
+        raw_data = COVID_API_V1.get_current_status() # Get all current data
+        if country_name.lower() not in ['us', 'uk'] and len(country_name) in [2]:
+            country_name = helper_lookup_country(country_name)
+            data = {k: v for k, v in raw_data.items() if country_name.lower() in k.lower()}
+        else:
+            data = {k: v for k, v in raw_data.items() if country_name.lower() == k.lower()}
+
+        # Add dt and ts
+        data['dt'] = raw_data['dt']
+        data['ts'] = raw_data['ts']
+
+        return data
+        
+
+    def get_formatted_timeseries():
+        raw_data = COVID_API_V1.get_time_series()
+        case = case.lower()
+
+        if case in ['confirmed', 'deaths', 'recovered']:
+            data = {case: raw_data[case]}
+            data['dt'] = raw_data['dt']
+            data['ts'] = raw_data['ts']
+        else:
+            raise HTTPException(status_code=404, detail="Item not found")
+
+        return data
+
+    def get_currrent_status_list():
+        return COVID_API_V1.get_current_status(list_required=True)

--- a/app/routers/v1/router_api_v1.py
+++ b/app/routers/v1/router_api_v1.py
@@ -12,7 +12,6 @@ from fastapi import HTTPException
 
 from integrators.covid_api_v1_integrator import CovidAPIv1
 from adapters.covid_api_v1_integrator_adapter import CovidAPIv1Adapter
-from utils.helper import helper_lookup_country
 from . import v1
 
 

--- a/app/routers/v1/router_api_v1.py
+++ b/app/routers/v1/router_api_v1.py
@@ -94,8 +94,8 @@ def country(country_name: str) -> Dict[str, Any]:
         data['ts'] = raw_data['ts']
 
     except:
-        raise HTTPException(status_code=404, detail="Item not found")
-
+        # make custom exception class (ItemNotFoundException)
+        
     return data
 
 


### PR DESCRIPTION
### Proposed Changes

* The current interface between the v1 API Router to the `CovidAPIv1` class is not clean. This interface could be made better and cleaner. However, this means the v1 Router interface no longer matches that of `CovidAPIv1` class.
* This issue of incompatibility can be solved using the adapter design pattern. A new adapter class `CovidAPIv1Adapter` is created so that the v1 Router and `CovidAPIv1` are compatible again.

### Checklist

* [X] Tests
* [ ] Translations
* [ ] Documentation